### PR TITLE
TreePrintableTest.checkXXX Optional unwrap support

### DIFF
--- a/src/main/java/walkingkooka/text/printer/TreePrintableTesting.java
+++ b/src/main/java/walkingkooka/text/printer/TreePrintableTesting.java
@@ -16,11 +16,13 @@
  */
 package walkingkooka.text.printer;
 
+import walkingkooka.Cast;
 import walkingkooka.test.Testing;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public interface TreePrintableTesting extends Testing {
@@ -102,18 +104,40 @@ public interface TreePrintableTesting extends Testing {
     // Testing.........................................................................................................
 
     default void checkEquals(final Object expected, final Object actual, final Supplier<String> message) {
-        if (expected instanceof TreePrintable && actual instanceof TreePrintable) {
-            this.checkEquals((TreePrintable) expected, (TreePrintable) actual, message);
+        if (expected instanceof Optional && actual instanceof Optional) {
+            final Optional<?> expectedOptional = Cast.to(expected);
+            final Optional<?> actualOptional = Cast.to(actual);
+
+            this.checkEquals(
+                    expectedOptional.orElse(null),
+                    actualOptional.orElse(null),
+                    message
+            );
         } else {
-            Testing.super.checkEquals(expected, actual, message);
+            if (expected instanceof TreePrintable && actual instanceof TreePrintable) {
+                this.checkEquals((TreePrintable) expected, (TreePrintable) actual, message);
+            } else {
+                Testing.super.checkEquals(expected, actual, message);
+            }
         }
     }
 
     default void checkNotEquals(final Object expected, final Object actual, final Supplier<String> message) {
-        if (expected instanceof TreePrintable && actual instanceof TreePrintable) {
-            this.checkNotEquals((TreePrintable) expected, (TreePrintable) actual, message);
+        if (expected instanceof Optional && actual instanceof Optional) {
+            final Optional<?> expectedOptional = Cast.to(expected);
+            final Optional<?> actualOptional = Cast.to(actual);
+
+            this.checkNotEquals(
+                    expectedOptional.orElse(null),
+                    actualOptional.orElse(null),
+                    message
+            );
         } else {
-            Testing.super.checkNotEquals(expected, actual, message);
+            if (expected instanceof TreePrintable && actual instanceof TreePrintable) {
+                this.checkNotEquals((TreePrintable) expected, (TreePrintable) actual, message);
+            } else {
+                Testing.super.checkNotEquals(expected, actual, message);
+            }
         }
     }
 }

--- a/src/test/java/walkingkooka/text/printer/TreePrintableTestingTest.java
+++ b/src/test/java/walkingkooka/text/printer/TreePrintableTestingTest.java
@@ -18,6 +18,8 @@ package walkingkooka.text.printer;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class TreePrintableTestingTest implements TreePrintableTesting {
@@ -108,6 +110,76 @@ public final class TreePrintableTestingTest implements TreePrintableTesting {
         boolean failed = false;
         try {
             this.checkNotEquals(new TestTreePrintable(printTree), new TestTreePrintable(printTree), "message");
+        } catch (final AssertionError expected) {
+            assertEquals("message ==> expected: not equal but was: <111>", expected.getMessage(), "message");
+            failed = true;
+        }
+        assertEquals(true, failed);
+    }
+
+    // checkEquals(Object,Object).......................................................................................
+
+    @Test
+    public void testCheckEqualsOptionalTreePrintable() {
+        this.checkEquals(
+                Optional.of(
+                        this.createTreePrintable()
+                ),
+                Optional.of(
+                        this.createTreePrintable()
+                ),
+                "message"
+        );
+    }
+
+    @Test
+    public void testCheckEqualsOptionalTreePrintableNullFails() {
+        boolean failed = false;
+        try {
+            this.checkEquals(
+                    Optional.of(
+                            this.createTreePrintable()
+                    ),
+                    Optional.ofNullable(
+                            NULL_TREE_PRINTABLE
+                    ), "message"
+            );
+        } catch (final AssertionError expected) {
+            failed = true;
+        }
+        assertEquals(true, failed);
+    }
+
+    // checkNotEquals(Object,Object)....................................................................................
+
+    @Test
+    public void testCheckNotEqualsOptionalTreePrintable() {
+        this.checkNotEquals(
+                Optional.of(
+                        new TestTreePrintable("111")
+                ),
+                Optional.of(
+                        new TestTreePrintable("222")
+                ),
+                "message"
+        );
+    }
+
+    @Test
+    public void testCheckNotEqualsOptionalTreePrintableFails() {
+        final String printTree = "111";
+
+        boolean failed = false;
+        try {
+            this.checkNotEquals(
+                    Optional.of(
+                            new TestTreePrintable(printTree)
+                    ),
+                    Optional.of(
+                            new TestTreePrintable(printTree)
+                    ),
+                    "message"
+            );
         } catch (final AssertionError expected) {
             assertEquals("message ==> expected: not equal but was: <111>", expected.getMessage(), "message");
             failed = true;


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-printer/issues/32
- TreePrintableTesting.checkEquals should unwrap Optional