### PR TITLE
SinkPrinter accept LineEnding

### DIFF
--- a/src/main/java/walkingkooka/text/printer/Printers.java
+++ b/src/main/java/walkingkooka/text/printer/Printers.java
@@ -58,8 +58,8 @@ final public class Printers implements PublicStaticHelper {
     /**
      * {@see SinkPrinter}.
      */
-    public static Printer sink() {
-        return SinkPrinter.INSTANCE;
+    public static Printer sink(final LineEnding lineEnding) {
+        return SinkPrinter.with(lineEnding);
     }
 
     /**

--- a/src/main/java/walkingkooka/text/printer/SinkPrinter.java
+++ b/src/main/java/walkingkooka/text/printer/SinkPrinter.java
@@ -19,21 +19,49 @@ package walkingkooka.text.printer;
 
 import walkingkooka.text.LineEnding;
 
+import java.util.Objects;
+
 /**
  * A {@link Printer} that ignores all {@link CharSequence sequences} added to it.
  */
 final class SinkPrinter implements Printer {
 
-    /**
-     * Singleton
-     */
-    final static SinkPrinter INSTANCE = new SinkPrinter();
+    static SinkPrinter with(final LineEnding lineEnding) {
+        Objects.requireNonNull(lineEnding, "lineEnding");
+
+        final SinkPrinter printer;
+
+        switch (lineEnding.toString()) {
+            case "\r":
+                printer = CR;
+                break;
+            case "\r\n":
+                printer = CRNL;
+                break;
+            case "\n":
+                printer = NL;
+                break;
+            case "":
+                printer = NONE;
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown lineEnding: " + lineEnding);
+        }
+
+        return printer;
+    }
+
+    private final static SinkPrinter CR = new SinkPrinter(LineEnding.CR);
+    private final static SinkPrinter CRNL = new SinkPrinter(LineEnding.CRNL);
+    private final static SinkPrinter NL = new SinkPrinter(LineEnding.NL);
+    private final static SinkPrinter NONE = new SinkPrinter(LineEnding.NONE);
 
     /**
      * Singleton
      */
-    private SinkPrinter() {
+    private SinkPrinter(final LineEnding lineEnding) {
         super();
+        this.lineEnding = lineEnding;
     }
 
     @Override
@@ -46,8 +74,10 @@ final class SinkPrinter implements Printer {
      */
     @Override
     public LineEnding lineEnding() throws PrinterException {
-        return LineEnding.NONE;
+        return this.lineEnding;
     }
+
+    private final LineEnding lineEnding;
 
     @Override
     public void flush() throws PrinterException {

--- a/src/test/java/walkingkooka/text/printer/SinkPrinterTest.java
+++ b/src/test/java/walkingkooka/text/printer/SinkPrinterTest.java
@@ -18,8 +18,10 @@
 package walkingkooka.text.printer;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.ToStringTesting;
+import walkingkooka.text.LineEnding;
 
-final public class SinkPrinterTest extends PrinterTestCase<SinkPrinter> {
+final public class SinkPrinterTest extends PrinterTestCase<SinkPrinter> implements ToStringTesting<SinkPrinter> {
 
     @Override
     @Test
@@ -29,7 +31,25 @@ final public class SinkPrinterTest extends PrinterTestCase<SinkPrinter> {
 
     @Test
     public void testPrintWorks() {
-        SinkPrinter.INSTANCE.print("string");
+        SinkPrinter.with(LineEnding.CR)
+                .print("string");
+    }
+
+    @Test
+    public void testLineEndingCr() {
+        this.checkEquals(
+                LineEnding.CR,
+                this.createPrinter().lineEnding()
+        );
+    }
+
+    @Test
+    public void testLineEndingNone() {
+        this.checkEquals(
+                LineEnding.NONE,
+                SinkPrinter.with(LineEnding.NONE)
+                        .lineEnding()
+        );
     }
 
     @Override
@@ -52,12 +72,15 @@ final public class SinkPrinterTest extends PrinterTestCase<SinkPrinter> {
 
     @Test
     public void testToString() {
-        this.checkEquals("sink", SinkPrinter.INSTANCE.toString());
+        this.toStringAndCheck(
+                this.createPrinter(),
+                "sink"
+        );
     }
 
     @Override
     public SinkPrinter createPrinter() {
-        return SinkPrinter.INSTANCE;
+        return SinkPrinter.with(LineEnding.CR);
     }
 
     @Override


### PR DESCRIPTION
- Previously SinkPrinter.lineEnding() always returns LineEnding.NONE