### PR TITLE
ignore PrinterWriter

### DIFF
--- a/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
+++ b/src/main/java/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
@@ -1,3 +1,4 @@
 **/*Testing*
 **/PrinterPrintStream.*
 **/WriterPrinter.*
+**/PrinterWriter.*


### PR DESCRIPTION
- Fix unnecessary gwt codeserver fails to compile because of missing java.io.Writer, even when unreachable.