### PR TITLE
TreePrintableTesting fail messages includes class name

### DIFF
--- a/src/main/java/walkingkooka/text/printer/TreePrintableTesting.java
+++ b/src/main/java/walkingkooka/text/printer/TreePrintableTesting.java
@@ -35,7 +35,7 @@ public interface TreePrintableTesting extends Testing {
                                    final String expected) {
         this.checkEquals(
                 expected,
-                printable.treeToString(INDENTATION, EOL),
+                TreePrintableTestingHelper.treePrint(printable),
                 printable::toString
         );
     }
@@ -64,8 +64,8 @@ public interface TreePrintableTesting extends Testing {
                              final Supplier<String> message) {
         if (!Objects.equals(expected, actual)) {
             this.checkEquals(
-                    null != expected ? expected.treeToString(INDENTATION, EOL) : null,
-                    null != actual ? actual.treeToString(INDENTATION, EOL) : null,
+                    TreePrintableTestingHelper.treePrint(expected),
+                    TreePrintableTestingHelper.treePrint(actual),
                     message
             );
         }
@@ -95,8 +95,8 @@ public interface TreePrintableTesting extends Testing {
                                 final Supplier<String> message) {
         if (Objects.equals(expected, actual)) {
             this.checkNotEquals(
-                    null != expected ? expected.treeToString(INDENTATION, EOL) : null,
-                    null != actual ? actual.treeToString(INDENTATION, EOL) : null,
+                    TreePrintableTestingHelper.treePrint(expected),
+                    TreePrintableTestingHelper.treePrint(actual),
                     message
             );
         }
@@ -125,7 +125,11 @@ public interface TreePrintableTesting extends Testing {
                             message
                     );
                 } else {
-                    Testing.super.checkEquals(expected, actual, message);
+                    Testing.super.checkEquals(
+                            expected,
+                            actual,
+                            message
+                    );
                 }
             }
         }
@@ -143,7 +147,11 @@ public interface TreePrintableTesting extends Testing {
             );
         } else {
             if (expected instanceof TreePrintable && actual instanceof TreePrintable) {
-                this.checkNotEquals((TreePrintable) expected, (TreePrintable) actual, message);
+                this.checkNotEquals(
+                        (TreePrintable) expected,
+                        (TreePrintable) actual,
+                        message
+                );
             } else {
                 if(TreePrintableTestingHelper.shouldTreePrint(actual) && TreePrintableTestingHelper.shouldTreePrint(expected)) {
                     Testing.super.checkNotEquals(
@@ -152,7 +160,11 @@ public interface TreePrintableTesting extends Testing {
                             message
                     );
                 } else {
-                    Testing.super.checkNotEquals(expected, actual, message);
+                    Testing.super.checkNotEquals(
+                            expected,
+                            actual,
+                            message
+                    );
                 }
             }
         }

--- a/src/main/java/walkingkooka/text/printer/TreePrintableTestingHelper.java
+++ b/src/main/java/walkingkooka/text/printer/TreePrintableTestingHelper.java
@@ -49,6 +49,26 @@ final class TreePrintableTestingHelper {
                 value instanceof TreePrintable;
     }
 
+    static String treePrint(final TreePrintable treePrintable) {
+        final StringBuilder b = new StringBuilder();
+
+        if(null != treePrintable) {
+            try (final IndentingPrinter printer = Printers.stringBuilder(
+                    b,
+                    LineEnding.SYSTEM
+            ).indenting(Indentation.SPACES2)) {
+                printer.println(treePrintable.getClass().getName());
+                printer.indent();
+                {
+                    treePrintable.printTree(printer);
+                }
+                printer.outdent();
+                printer.flush();
+            }
+        }
+        return b.toString();
+    }
+
     static String treePrint(final Collection<?> collection) {
         final StringBuilder b = new StringBuilder();
         final IndentingPrinter printer = Printers.stringBuilder(b, LineEnding.SYSTEM)

--- a/src/test/java/walkingkooka/text/printer/TreePrintableTestingTest.java
+++ b/src/test/java/walkingkooka/text/printer/TreePrintableTestingTest.java
@@ -50,9 +50,10 @@ public final class TreePrintableTestingTest implements TreePrintableTesting {
     public void testTreePrintAndCheck() {
         this.treePrintAndCheck(
                 TREE_PRINTABLE,
-                "Before1\n" +
-                        "  Between2\n" +
-                        "After3\n"
+                "walkingkooka.text.printer.TreePrintableTestingTest$1\n" +
+                        "  Before1\n" +
+                        "    Between2\n" +
+                        "  After3\n"
         );
     }
 
@@ -205,7 +206,12 @@ public final class TreePrintableTestingTest implements TreePrintableTesting {
         try {
             this.checkNotEquals(new TestTreePrintable(printTree), new TestTreePrintable(printTree), "message");
         } catch (final AssertionError expected) {
-            assertEquals("message ==> expected: not equal but was: <111>", expected.getMessage(), "message");
+            assertEquals(
+                    "message ==> expected: not equal but was: <walkingkooka.text.printer.TreePrintableTestingTest$TestTreePrintable\n" +
+                            "  111>",
+                    expected.getMessage(),
+                    "message"
+            );
             failed = true;
         }
         assertEquals(true, failed);
@@ -275,7 +281,12 @@ public final class TreePrintableTestingTest implements TreePrintableTesting {
                     "message"
             );
         } catch (final AssertionError expected) {
-            assertEquals("message ==> expected: not equal but was: <111>", expected.getMessage(), "message");
+            assertEquals(
+                    "message ==> expected: not equal but was: <walkingkooka.text.printer.TreePrintableTestingTest$TestTreePrintable\n" +
+                            "  111>",
+                    expected.getMessage(),
+                    "message"
+            );
             failed = true;
         }
         assertEquals(true, failed);
@@ -297,7 +308,13 @@ public final class TreePrintableTestingTest implements TreePrintableTesting {
                     (Object) new TestTreePrintable("different")
             );
         } catch (final AssertionError expected) {
-            assertEquals("expected: <123> but was: <different>", expected.getMessage(), "message");
+            assertEquals(
+                    "expected: <walkingkooka.text.printer.TreePrintableTestingTest$TestTreePrintable\n" +
+                            "  123> but was: <walkingkooka.text.printer.TreePrintableTestingTest$TestTreePrintable\n" +
+                            "  different>",
+                    expected.getMessage(),
+                    "message"
+            );
             failed = true;
         }
         assertEquals(true, failed);
@@ -317,7 +334,12 @@ public final class TreePrintableTestingTest implements TreePrintableTesting {
                     (Object) new TestTreePrintable("same")
             );
         } catch (final AssertionError expected) {
-            assertEquals("expected: not equal but was: <same>", expected.getMessage(), "message");
+            assertEquals(
+                    "expected: not equal but was: <walkingkooka.text.printer.TreePrintableTestingTest$TestTreePrintable\n" +
+                            "  same>",
+                    expected.getMessage(),
+                    "message"
+            );
             failed = true;
         }
         assertEquals(true, failed);


### PR DESCRIPTION
- This should help spot assertions for equality of different types.
- NOTE collection elements do not have the type for each element printed.