### PR TITLE
TreePrintableTesting.treePrintAndCheck(TreePrintable,String) removed …

### DIFF
--- a/src/main/java/walkingkooka/text/printer/TreePrintableTesting.java
+++ b/src/main/java/walkingkooka/text/printer/TreePrintableTesting.java
@@ -18,6 +18,8 @@ package walkingkooka.text.printer;
 
 import walkingkooka.Cast;
 import walkingkooka.test.Testing;
+import walkingkooka.text.Indentation;
+import walkingkooka.text.LineEnding;
 
 import java.util.Collection;
 import java.util.Objects;
@@ -30,7 +32,10 @@ public interface TreePrintableTesting extends Testing {
                                    final String expected) {
         this.checkEquals(
                 expected,
-                TreePrintableTestingHelper.treePrint(printable),
+                printable.treeToString(
+                        Indentation.SPACES2,
+                        LineEnding.SYSTEM
+                ),
                 printable::toString
         );
     }
@@ -59,8 +64,8 @@ public interface TreePrintableTesting extends Testing {
                              final Supplier<String> message) {
         if (!Objects.equals(expected, actual)) {
             this.checkEquals(
-                    TreePrintableTestingHelper.treePrint(expected),
-                    TreePrintableTestingHelper.treePrint(actual),
+                    TreePrintableTestingHelper.treePrintWithClassName(expected),
+                    TreePrintableTestingHelper.treePrintWithClassName(actual),
                     message
             );
         }
@@ -90,8 +95,8 @@ public interface TreePrintableTesting extends Testing {
                                 final Supplier<String> message) {
         if (Objects.equals(expected, actual)) {
             this.checkNotEquals(
-                    TreePrintableTestingHelper.treePrint(expected),
-                    TreePrintableTestingHelper.treePrint(actual),
+                    TreePrintableTestingHelper.treePrintWithClassName(expected),
+                    TreePrintableTestingHelper.treePrintWithClassName(actual),
                     message
             );
         }

--- a/src/main/java/walkingkooka/text/printer/TreePrintableTestingHelper.java
+++ b/src/main/java/walkingkooka/text/printer/TreePrintableTestingHelper.java
@@ -49,10 +49,10 @@ final class TreePrintableTestingHelper {
                 value instanceof TreePrintable;
     }
 
-    static String treePrint(final TreePrintable treePrintable) {
+    static String treePrintWithClassName(final TreePrintable treePrintable) {
         final StringBuilder b = new StringBuilder();
 
-        if(null != treePrintable) {
+        if (null != treePrintable) {
             try (final IndentingPrinter printer = Printers.stringBuilder(
                     b,
                     LineEnding.SYSTEM

--- a/src/test/java/walkingkooka/text/printer/TreePrintableTestingTest.java
+++ b/src/test/java/walkingkooka/text/printer/TreePrintableTestingTest.java
@@ -50,10 +50,9 @@ public final class TreePrintableTestingTest implements TreePrintableTesting {
     public void testTreePrintAndCheck() {
         this.treePrintAndCheck(
                 TREE_PRINTABLE,
-                "walkingkooka.text.printer.TreePrintableTestingTest$1\n" +
-                        "  Before1\n" +
-                        "    Between2\n" +
-                        "  After3\n"
+                "Before1\n" +
+                        "  Between2\n" +
+                        "After3\n"
         );
     }
 


### PR DESCRIPTION
…type name *FIX*

- This will fix all tests that were calling this which failed because they didnt include the classname on the first line.